### PR TITLE
Ensure keyword "jupyterlab extension" in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "description": "Show a random xkcd.com comic in a JupyterLab panel",
   "keywords": [
-    "extension",
     "jupyter",
-    "jupyterlab"
+    "jupyterlab",
+    "jupyterlab extension"
   ],
   "homepage": "https://github.com/jupyterlab/jupyterlab_xkcd",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "jupyter",
     "jupyterlab",
-    "jupyterlab extension"
+    "jupyterlab-extension"
   ],
   "homepage": "https://github.com/jupyterlab/jupyterlab_xkcd",
   "bugs": {


### PR DESCRIPTION
Ensures any who copy the package.json of this project as a starting point of their own extension gets the keyword "jupyterlab extension". This should help with discoverability of published extensions, as it is a very specific keyword.