### PR TITLE
Update to JupyterLab 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 lib/
 node_modules/
 *.egg-info/
+yarn.lock
+tsconfig.tsbuildinfo
+package-lock.json
 
 # Jupyter Notebook Checkpoints
 .ipynb_checkpoints

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
+# Distribution / packaging
 *.bundle.*
 lib/
 node_modules/
 *.egg-info/
+
+# Jupyter Notebook Checkpoints
 .ipynb_checkpoints
+
+# PyCharm
+.idea/
+*.iml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/xkcd-extension",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Show a random xkcd.com comic in a JupyterLab panel",
   "keywords": [
     "jupyter",
@@ -25,20 +25,20 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rimraf lib",
+    "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "prepare": "npm run clean && npm run build",
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@jupyterlab/application": "^0.19.1",
-    "@jupyterlab/apputils": "^0.19.1",
+    "@jupyterlab/application": "^1.0.0",
+    "@jupyterlab/apputils": "^1.0.0",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
-    "@phosphor/widgets": "^1.6.0"
+    "@phosphor/widgets": "^1.7.0"
   },
   "devDependencies": {
-    "rimraf": "^2.6.1",
-    "typescript": "~3.1.1"
+    "rimraf": "^2.6.3",
+    "typescript": "~3.5.2"
   },
   "jupyterlab": {
     "extension": true

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import {
-  JupyterLab, JupyterLabPlugin, ILayoutRestorer
+  JupyterFrontEnd, JupyterFrontEndPlugin, ILayoutRestorer
 } from '@jupyterlab/application';
 
 import {
-  ICommandPalette, InstanceTracker
+  ICommandPalette, WidgetTracker
 } from '@jupyterlab/apputils';
 
 import {
@@ -72,7 +72,7 @@ class XkcdWidget extends Widget {
 /**
  * Activate the xckd widget extension.
  */
-function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRestorer) {
+function activate(app: JupyterFrontEnd, palette: ICommandPalette, restorer: ILayoutRestorer) {
   console.log('JupyterLab extension jupyterlab_xkcd is activated!');
 
   // Declare a widget variable
@@ -94,7 +94,7 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRe
       }
       if (!widget.isAttached) {
         // Attach the widget to the main work area if it's not there
-        app.shell.addToMainArea(widget);
+        app.shell.add(widget, 'main');
       } else {
         // Refresh the comic in the widget
         widget.update();
@@ -108,7 +108,7 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRe
   palette.addItem({ command, category: 'Tutorial' });
 
   // Track and restore the widget state
-  let tracker = new InstanceTracker<Widget>({ namespace: 'xkcd' });
+  let tracker = new WidgetTracker<Widget>({ namespace: 'xkcd' });
   restorer.restore(tracker, {
     command,
     args: () => JSONExt.emptyObject,
@@ -120,7 +120,7 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRe
 /**
  * Initialization data for the jupyterlab_xkcd extension.
  */
-const extension: JupyterLabPlugin<void> = {
+const extension: JupyterFrontEndPlugin<void> = {
   id: 'jupyterlab_xkcd',
   autoStart: true,
   requires: [ICommandPalette, ILayoutRestorer],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,23 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
     "declaration": true,
-    "lib": ["es2015", "dom"],
-    "module": "commonjs",
+    "esModuleInterop": true,
+    "incremental": true,
+    "jsx": "react",
+    "module": "esnext",
     "moduleResolution": "node",
     "noEmitOnError": true,
+    "noImplicitAny": true,
     "noUnusedLocals": true,
+    "preserveWatchOutput": true,
+    "resolveJsonModule": true,
     "outDir": "lib",
     "rootDir": "src",
     "strict": true,
     "strictNullChecks": false,
-    "target": "es2015",
+    "target": "es2017",
     "types": []
   },
   "include": ["src/*"]


### PR DESCRIPTION
Update the xkcd extension to conform to the current APIs in JupyterLab 1.0.0.

Following the repository pattern, this should become a branch with the same version of the JupyterLab release version, thus this should be merged to a 1.0.0 branch.
